### PR TITLE
Add ability to create with id's and import from json

### DIFF
--- a/sgmock/shotgun.py
+++ b/sgmock/shotgun.py
@@ -5,6 +5,7 @@ import datetime
 import re
 import itertools
 import logging
+import json
 
 import shotgun_api3
 
@@ -382,3 +383,94 @@ class Shotgun(object):
     def clear(self):
         self._store.clear()
         self._deleted.clear()
+
+    def sgmock_json_dump(self, *args, **kwargs):
+        """ Saves the current state of the db to json.
+
+        This converts datetime objects to isoformat strings(including
+        trailing z) so they can be saved to json. sgmock_json_load
+        will restore these strings to datetime objects. All args and
+        kwargs are passed to json.dump. Do not pass a object to be
+        serialized it is provided automatically.
+
+        :param \*args: All args are passed to json.load
+        :param \**kwargs: All kwargs are passed to json.load
+        """
+        if kwargs.get('default', None) is None:
+            def serialize(value):
+                """ Serialize objects that are not supported by json.
+                """
+                if isinstance(value, datetime.datetime):
+                    return value.isoformat() + 'Z'
+                elif isinstance(value, datetime.date):
+                    return value.isoformat()
+                return json.JSONEncoder().default(value)
+            kwargs['default']=serialize
+        json.dump(dict(self._store), *args, **kwargs)
+
+    def sgmock_json_load(self, *args, **kwargs):
+        """ Load the contents of json over the current entities.
+
+        Replaces any records with the contents of the json file object.
+        Automatically converts isoformat datetime strings(including
+        trailing z) to datetime objects.
+
+        :param \*args: All args are passed to json.load
+        :param \**kwargs: All kwargs are passed to json.load
+        """
+        try:
+            strtype = basestring
+        except NameError:
+            # using Python 3
+            strtype = str
+
+        objects = json.load(*args, **kwargs)
+        entity_ids = collections.defaultdict(int)
+
+        # the loaded json data is not exactly what we need for self._store
+        for entity_type, entities in objects.items():
+            # json keys must be strings.
+            ids = set()
+            for sid in entities.keys():
+                # Convert the string id from json to the expected int value
+                entity_id = int(sid)
+                ids.add(entity_id)
+                entities[entity_id] = entities.pop(sid)
+
+                for field in entities[entity_id]:
+                    value = entities[entity_id][field]
+                    if isinstance(value, strtype):
+                        # Convert isoformat datestrings to dattime objects
+                        pattern = (
+                            # Date
+                            '(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})'
+                            # Time
+                            '(?:T(?P<hour>\d{2}):(?P<minute>\d{2}):'
+                            '(?P<second>\d{2})(?:.(?P<microsecond>\d{6}))?Z)?'
+                        )
+                        match = re.match(pattern, value)
+                        if match:
+                            groupdict = match.groupdict()
+                            if groupdict['hour'] is None:
+                                # It's a date object
+                                createClass = datetime.date
+                                groupdict.pop('hour')
+                                groupdict.pop('minute')
+                                groupdict.pop('second')
+                                groupdict.pop('microsecond')
+                            else:
+                                # its a datetime object
+                                createClass = datetime.datetime
+
+                            entities[entity_id][field] = createClass(
+                                **{k: int(v) for k, v in groupdict.items()}
+                            )
+
+            # Store the largest entity id so the index is correct.
+            entity_ids[entity_type] = max(ids)
+        # Store the json data to the existing _store
+        self._store = collections.defaultdict(dict, objects)
+        # Update the index so new entities get a valid id.
+        self._ids = entity_ids
+        # clear the other container variables so we start fresh
+        self._deleted = collections.defaultdict(dict)

--- a/sgmock/shotgun.py
+++ b/sgmock/shotgun.py
@@ -182,13 +182,27 @@ class Shotgun(object):
 
         # Get or create the entity.
         if entity_id is None:
+            # Generate a default new sequential id
+            newId = self._ids[entity_type] + 1
+            if 'id' in data:
+                # for more complicated unit tests its nice to be able to create
+                # records with known id's.
+                if data['id'] in self._store[entity_type]:
+                    msg = 'there is already a "{type}" record with the "id" {id}'
+                    raise ShotgunError(msg.format(type=entity_type, id=data['id']))
+                else:
+                    # If data contains a id and that id is not already used,
+                    # create the new entity with the passed in id.
+                    newId = data['id']
             entity = {
                 'type': entity_type,
-                'id': self._ids[entity_type] + 1,
+                'id': newId,
                 'created_at': datetime.datetime.utcnow(),
                 #'created_by': self._creator,
             }
-            self._ids[entity_type] = entity['id']
+            # Update the id index to the new id only if its larger than
+            # the previous value.
+            self._ids[entity_type] = max(entity['id'], self._ids[entity_type])
             self._store[entity_type][entity['id']] = entity
         else:
             # TODO: Handle this gracefully.

--- a/tests/test_create_with_id.py
+++ b/tests/test_create_with_id.py
@@ -1,0 +1,44 @@
+from common import *
+
+
+class TestCreateWithId(TestCase):
+
+    def test_create_default_return(self):
+        sg = Shotgun()
+        type_ = 'Dummy' + mini_uuid().upper()
+
+        # Verify that the Shotgun._id index is reset
+        self.assertEqual(sg._ids[type_], 0)
+
+        # Create a entity with a specific id
+        spec = dict(name=mini_uuid(), id=10)
+        proj = sg.create(type_, spec)
+        self.assertEqual(proj['id'], 10)
+        # It should have updated the Shotgun._id index
+        self.assertEqual(sg._ids[type_], 10)
+
+        # Create a entity with a smaller id.
+        spec = dict(name=mini_uuid(), id=5)
+        proj1 = sg.create(type_, spec)
+        self.assertEqual(proj1['id'], 5)
+        # It should not have updated the Shotgun._id index
+        self.assertEqual(sg._ids[type_], 10)
+
+        # Creating a new entity without passing in id should increment the index
+        spec = dict(name=mini_uuid())
+        proj = sg.create(type_, spec)
+        self.assertEqual(proj['id'], 11)
+        self.assertEqual(sg._ids[type_], 11)
+
+        # Verify that creating a new record with a duplicate id is not allowed.
+        spec = dict(name=mini_uuid(), id=10)
+        self.assertRaises(ShotgunError, sg.create, type_, spec)
+
+        # Verify that update ignores the id value if passed in data
+        spec = dict(name=mini_uuid(), id=3)
+        updated = sg.update(type_, 10, spec)
+        self.assertEqual(updated['id'], 10)
+        self.assertEqual(updated['name'], spec['name'])
+        self.assertNotEqual(updated['name'], proj['name'])
+        # Verify that the id index was not updated
+        self.assertEqual(sg._ids[type_], 11)

--- a/tests/test_json_db_source.py
+++ b/tests/test_json_db_source.py
@@ -1,0 +1,75 @@
+import json
+import shutil
+import tempfile
+import datetime
+from common import *
+
+type_ = 'Dummy' + mini_uuid().upper()
+
+class TestJsonDbSource(TestCase):
+
+    def test_json_save_and_load(self):
+        sgSource = Shotgun()
+        # Create some test values
+        adate = datetime.date.today() + datetime.timedelta(days=3)
+        spec = dict(name=mini_uuid(), id=10, adate=adate)
+        proj1 = sgSource.create(type_, spec, return_fields=['name', 'created_at'])
+
+        spec = dict(name=mini_uuid(), id=5)
+        proj2 = sgSource.create(type_, spec)
+
+        spec = dict(name=mini_uuid()) # id should be 11
+        proj3 = sgSource.create(type_, spec)
+
+        def validateDatabase(sg):
+            entity1 = sg.find_one(type_, [['id', 'is', 10]], ['name', 'created_at', 'adate'])
+            entity2 = sg.find_one(type_, [['id', 'is', 5]], ['name'])
+            entity3 = sg.find_one(type_, [['id', 'is', 11]], ['name'])
+
+            # Verify that the found entity is the same as originally created
+            self.assertSameEntity(proj1, entity1)
+            self.assertSameEntity(proj2, entity2)
+            self.assertSameEntity(proj3, entity3)
+
+            # Check that extra fields are the same.
+            msg = 'Source name: {s} does not match dest name: {d}'
+            self.assertEqual(proj1['name'], entity1['name'],
+                msg.format(s=proj1['name'], d=entity1['name']))
+            self.assertEqual(proj2['name'], entity2['name'],
+                msg.format(s=proj1['name'], d=entity1['name']))
+            self.assertEqual(proj3['name'], entity3['name'],
+                msg.format(s=proj1['name'], d=entity1['name']))
+
+            # Check that datetime.datetime objects were restored correctly
+            msg = 'Source datetime: {s} does not match dest datetime: {d}'
+            self.assertEqual(proj1['created_at'], entity1['created_at'],
+                msg.format(s=proj1['created_at'], d=entity1['created_at']))
+
+            # Check that datetime.date objects were restored correctly
+            msg = 'Source date: {s} does not match dest date: {d}'
+            self.assertEqual(adate, entity1['adate'],
+                msg.format(s=adate, d=entity1['adate']))
+            self.assertEqual(proj1['adate'], entity1['adate'],
+                msg.format(s=proj1['adate'], d=entity1['adate']))
+
+        # Validate that our source db is setup as expected
+        validateDatabase(sgSource)
+
+        with tempfile.TemporaryFile(prefix='sgmock_') as fp:
+            # Save the source db to disk.
+            sgSource.sgmock_json_dump(fp, indent=4)
+
+            # Create a new empty shotgun connection and db
+            sgDest = Shotgun()
+            self.assertEqual(len(sgDest._store), 0)
+
+            # Move to the beginning of the tempfile so we can read it
+            fp.seek(0)
+            # import the json data from file to the new db.
+            sgDest.sgmock_json_load(fp)
+
+        # validate that the new db was properly loaded from json data
+        validateDatabase(sgDest)
+
+        # Ensure the id index is updated to the largest created entity id
+        self.assertEqual(sgDest._ids[type_], 11)


### PR DESCRIPTION
Adds two features:

- If you include id in the dict passed to `sgmock.Shotgun().create`, it will use that id for the created record, or error out if its already in use.
- You can save the current database to a json file and restore the json data to a new Shotgun object.

I need to test syncing between our internal database and shotgun. We handle this by storing the database id's in both databases. To make these tests easy to write, I need to know what id each record has.

I also need a lot of data to test with, more than I want to have to manually write the create calls for.