### PR TITLE
Add ends_with filter and test filter statements

### DIFF
--- a/sgmock/filters.py
+++ b/sgmock/filters.py
@@ -155,3 +155,10 @@ class StartsWithFilter(ScalarFilter):
 
     def test(self, value, field):
         return field.startswith(value)
+
+
+@register('ends_with')
+class EndsWithFilter(ScalarFilter):
+
+    def test(self, value, field):
+        return field.endswith(value)

--- a/sgmock/unittest.py
+++ b/sgmock/unittest.py
@@ -36,8 +36,8 @@ class TestCase(BaseTestCase):
         if not errors:
             if a['type'] != b['type']:
                 errors.append('types do not match; %r != %r' % (a['type'], b['type']))
-                if a['id'] != b['id']:
-                    errors.append('ids do not match; %r != %r' % (a['id'], b['id']))
+            elif a['id'] != b['id']:
+                errors.append('ids do not match; %r != %r' % (a['id'], b['id']))
         
         if errors:
             self.fail(msg or '; '.join(errors))

--- a/tests/test_assertion.py
+++ b/tests/test_assertion.py
@@ -1,0 +1,35 @@
+from common import *
+
+
+class TestAssertion(TestCase):
+
+    def test_assertSameEntity(self):
+        pa = dict(type='Project', id=1, name='ProjectA')
+        pb = dict(type='Project', id=2, name='ProjectB')
+        sa = dict(type='Shot', id=1, name='ShotA')
+
+        # Two entities with the same id's are found equal
+        self.assertSameEntity(pa, dict(type='Project', id=1))
+
+        # The two entities with the same id's but different types
+        with self.assertRaises(AssertionError):
+            self.assertSameEntity(pa, sa)
+
+        # The two entities have the same type but different id's
+        with self.assertRaises(AssertionError):
+            self.assertSameEntity(pa, pb)
+
+    def test_assertNotSameEntity(self):
+        pa = dict(type='Project', id=1, name='ProjectA')
+        pb = dict(type='Project', id=2, name='ProjectB')
+        sa = dict(type='Shot', id=1, name='ShotA')
+
+        self.assertNotSameEntity(pa, pb)
+        # The two entities have the same type and id
+        with self.assertRaises(AssertionError):
+            self.assertNotSameEntity(pa, pa)
+        with self.assertRaises(AssertionError):
+            self.assertNotSameEntity(pa, dict(type='Project', id=1))
+
+        # The two entities have different types but the same id's
+        self.assertNotSameEntity(pa, sa)

--- a/tests/test_basic_find.py
+++ b/tests/test_basic_find.py
@@ -65,3 +65,12 @@ class TestBasicFind(TestCase):
         self.assertEqual(len(c), 1)
         self.assertSameEntity(b, c[0])
         self.assertEqual(c[0]['name'], nameB)
+
+    def test_ends_with(self):
+        sg = Shotgun()
+        nameA, a, nameB, b = self.createTwoProjects(sg)
+        filters = [['name', 'ends_with', '_ProjectB']]
+        c = sg.find('Project', filters, ['name'])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(b, c[0])
+        self.assertEqual(c[0]['name'], nameB)

--- a/tests/test_basic_find.py
+++ b/tests/test_basic_find.py
@@ -3,6 +3,13 @@ from common import *
 
 class TestBasicFind(TestCase):
 
+    def createTwoProjects(self, sg):
+        nameA = 'A_Project_{}_ProjectA'.format(mini_uuid())
+        a = sg.create('Project', dict(name=nameA))
+        nameB = 'B_Project_{}_ProjectB'.format(mini_uuid())
+        b = sg.create('Project', dict(name=nameB))
+        return nameA, a, nameB, b
+
     def test_create_and_find_only_one_by_name(self):
         sg = Shotgun()
         name = mini_uuid()
@@ -11,3 +18,50 @@ class TestBasicFind(TestCase):
         self.assertSameEntity(a, b)
         b = sg.find('Project', [('id', 'is', a['id'])])[0]
         self.assertSameEntity(a, b)
+
+    def test_create_is_not(self):
+        sg = Shotgun()
+        nameA, a, nameB, b = self.createTwoProjects(sg)
+        c = sg.find('Project', [['name', 'is_not', nameA]])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(b, c[0])
+        c = sg.find('Project', [['name', 'is_not', nameB]])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(a, c[0])
+
+        c = sg.find('Project', [('id', 'is_not', a['id'])])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(b, c[0])
+
+    def test_less_than(self):
+        sg = Shotgun()
+        nameA, a, nameB, b = self.createTwoProjects(sg)
+        c = sg.find('Project', [['id', 'less_than', 2]])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(a, c[0])
+
+        c = sg.find('Project', [['id', 'less_than', 3]])
+        self.assertEqual(len(c), 2)
+        self.assertSameEntity(a, c[0])
+        self.assertSameEntity(b, c[1])
+
+    def test_greater_than(self):
+        sg = Shotgun()
+        nameA, a, nameB, b = self.createTwoProjects(sg)
+        c = sg.find('Project', [['id', 'greater_than', 1]])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(b, c[0])
+
+        c = sg.find('Project', [['id', 'greater_than', 0]])
+        self.assertEqual(len(c), 2)
+        self.assertSameEntity(a, c[0])
+        self.assertSameEntity(b, c[1])
+
+    def test_starts_with(self):
+        sg = Shotgun()
+        nameA, a, nameB, b = self.createTwoProjects(sg)
+        filters = [['name', 'starts_with', 'B_Project_']]
+        c = sg.find('Project', filters, ['name'])
+        self.assertEqual(len(c), 1)
+        self.assertSameEntity(b, c[0])
+        self.assertEqual(c[0]['name'], nameB)

--- a/tests/test_complex_filter_find.py
+++ b/tests/test_complex_filter_find.py
@@ -32,7 +32,7 @@ class TestComplexFilterFind(TestCase):
             {
                 'filter_operator': op_any,
                 'filters': [
-                    ['name', 'is', nameB],
+                    ['name', 'is', nameA],
                     ['sg_status', 'is', 'Production'],
                 ]
             }


### PR DESCRIPTION
1. Add support the `'ends_with'` filter, and add tests for it.
2. I found that `assertSameEntity` ignores the `'id'` value if the type of the entities matches. I fixed this and added tests for `assertSameEntity` and `assertNotSameEntity`. This includes a fix for my previous test that was incorrect.
3. I added basic tests for all the existing filters.